### PR TITLE
add support implicit tag

### DIFF
--- a/src/Emmet/Parser.purs
+++ b/src/Emmet/Parser.purs
@@ -47,7 +47,12 @@ parseId :: EmmetParser Attribute
 parseId = char '#' *> (Id <<< fromCharList <$> some classChar)
 
 parseElement :: EmmetParser Emmet
-parseElement = element <$> parseElementName <*> many (parseClass <|> parseId)
+parseElement = explicitTag <|> implicitTag
+  where
+    explicitTag = element <$> parseElementName <*> many (parseClass <|> parseId)
+
+    -- #page.full-width>header.bigger  --> div#page.full-width>header.bigger
+    implicitTag = element <$> pure "div" <*> some (parseClass <|> parseId)
 
 parseEmmet :: EmmetParser Emmet
 parseEmmet = do


### PR DESCRIPTION
When I use this great tool, I find `#page` can not be generated. So I add this support. Just for fun.

For the sake of simplicity, it just convert  to div tag.